### PR TITLE
Cosmetic changes and cleaning of default params.

### DIFF
--- a/manifests/acl.pp
+++ b/manifests/acl.pp
@@ -1,6 +1,16 @@
+# Define: openldap_slapd::acl
+# ===========================
+#
+# Access control block
+# Creates a configuration block:
+# access to
+#   $name
+#   by $rules[0]['by'] $rules[0]['action']
+#   by $rules[1]['by'] $rules[1]['action']
+#   ...
 define openldap_slapd::acl (
-  $to = $name,
   $rules,
+  $to = $name,
   $order = '50',
   $position = '',
   $target = $::openldap_slapd::conf_file,

--- a/manifests/authz.pp
+++ b/manifests/authz.pp
@@ -1,12 +1,17 @@
-# Authz-DN mappings
-
+# Define: openldap_slapd::authz
+# =============================
+#
+# authz-regexp mappings
+# Creates a configuration block:
+# authz-regexp
+#   "$name"
+#   "$map"
 define openldap_slapd::authz (
-  $match      = $name,
   $map,
+  $match      = $name,
   $order      = '60',
   $target     = $::openldap_slapd::conf_file,
 ) {
-
 
   concat::fragment { "openldap::authz::${name}":
     content => template('openldap_slapd/_authz.erb'),

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -1,3 +1,8 @@
+# Define: openldap_slapd::database
+# ================================
+#
+# Database
+# Create configuration block for one database
 define openldap_slapd::database (
   $acls = {},
   $add_content_acl = undef,
@@ -33,7 +38,7 @@ define openldap_slapd::database (
       group   => 'ldap',
       mode    => '0700',
       require => Package['openldap-servers'],
-    } 
+    }
   }
 
   # List databases alphabetically
@@ -44,6 +49,6 @@ define openldap_slapd::database (
   }
 
   # Append the database's name to order to get the acls under the correct db.
-  create_resources('openldap_slapd::acl', $acls, { "order" => "${order}_${name}_9" })
+  create_resources('openldap_slapd::acl', $acls, { 'order' => "${order}_${name}_9" })
 }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,31 +47,30 @@ class openldap_slapd (
   $authz_regexp            = {},
   $conf_file               = $openldap_slapd::params::conf_file,
   $databases               = {},
-  $global_acls             = $openldap_slapd::params::global_acls,
-  $local_ssf               = $openldap_slapd::params::local_ssf,
+  $global_acls             = undef,
+  $local_ssf               = undef,
   $log_level               = $openldap_slapd::params::log_level,
   $modules                 = [],
-  $password_hash           = $openldap_slapd::params::password_hash,
-  $password_salt_format    = $openldap_slapd::params::password_salt_format,
+  $password_hash           = undef,
+  $password_salt_format    = undef,
   $pidfile                 = $openldap_slapd::params::pidfile,
-  $schema_dir              = $openldap_slapd::params::schema_dir,
   $schemas                 = {},
-  $sec_allow               = $openldap_slapd::params::sec_allow,
-  $sec_disallow            = $openldap_slapd::params::sec_disallow,
-  $sec_require             = $openldap_slapd::params::sec_require,
-  $security                = $openldap_slapd::params::security,
+  $sec_allow               = undef,
+  $sec_disallow            = undef,
+  $sec_require             = undef,
+  $security                = undef,
   $server_id               = $openldap_slapd::params::server_id,
   $sizelimit               = undef,
   $threads                 = $openldap_slapd::params::threads,
   $timelimit               = undef,
-  $tls_ca_certificate_file = $openldap_slapd::params::tls_ca_certificate_file,
+  $tls_ca_certificate_file = undef,
   $tls_ca_certificate_path = undef,
-  $tls_certificate_file    = $openldap_slapd::params::tls_certificate_file,
-  $tls_cipher_suite        = $openldap_slapd::params::tls_cipher_suite,
-  $tls_dh_param_file       = $openldap_slapd::params::tls_dh_param_file,
-  $tls_enabled             = $openldap_slapd::params::tls_enabled,
-  $tls_key_file            = $openldap_slapd::params::tls_key_file,
-  $tls_protocol_min        = $openldap_slapd::params::tls_protocol_min,
+  $tls_certificate_file    = undef,
+  $tls_cipher_suite        = undef,
+  $tls_dh_param_file       = undef,
+  $tls_enabled             = undef,
+  $tls_key_file            = undef,
+  $tls_protocol_min        = undef,
 ) inherits openldap_slapd::params {
 
   package { 'openldap-servers':
@@ -116,7 +115,7 @@ class openldap_slapd (
     content => template('openldap_slapd/_security.erb')
   }
 
-  if $tls_enabled == true {
+  if str2bool("$tls_enabled") {
     concat::fragment { 'openldap_slapd::tls':
       order   => '30',
       content => template('openldap_slapd/_tls.erb')
@@ -132,5 +131,4 @@ class openldap_slapd (
   if $global_acls {
     create_resources('openldap_slapd::acl', $global_acls)
   }
-  
 }

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -1,3 +1,7 @@
+# Define: openldap_slapd::module
+# ==============================
+#
+# Create a list modules to load.
 define openldap_slapd::module (
   $modulename = $name,
   $order      = '10',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,47 +1,16 @@
+# Class: openldap_slapd::params
+# =============================
+#
+# Default parameters
 class openldap_slapd::params {
 
-
   $conf_file  = '/etc/openldap/slapd.conf'
-  $schema_dir = '/etc/openldap/schema'
 
   ## Global settings
 
   $server_id   = '01'
-  $threads     = '4'
+  $threads     = '16'
   $pidfile     = '/var/run/openldap/slapd.pid'
   $argsfile    = '/var/run/openldap/slapd.args'
   $log_level   = 'stats'
-  $tls_enabled = true
-
-  ## TLS options
-  #$tls_protocol_min        = '3.1'
-  #$tls_cipher_suite        = 'HIGH:!SSLv3:!SSLv2:!ADH'
-  $tls_certificate_file    = ''
-  $tls_key_file            = ''
-  $tls_ca_certificate_file = ''
-  #$tls_dh_param_file       = '/etc/openldap/ssl.key/dhparam'
-  $password_hash           = '{CRYPT}'
-  $password_salt_format    = '$6$%.12s'
-  $sec_disallow            = ''
-  $sec_allow               = ''
-  $sec_require             = ''
-  $security                = ''
-  $local_ssf               = ''
-  
-  $global_acls = {
-    
-    'dn.base=""'  => {
-      rules       => [
-        { 'by'    => '*', 'action' => 'read' },
-      ],
-      position       => 1,
-    },
-
-    'dn.base="cn=Subschema"' => {
-      rules       => [
-        { 'by'    => '*', 'action' => 'read' },
-      ],
-      position       => 2,
-    }
-  }
 }

--- a/manifests/schema.pp
+++ b/manifests/schema.pp
@@ -1,3 +1,7 @@
+# Define: openldap_slapd::schema
+# ==============================
+#
+# Create list of schemas to include.
 define openldap_slapd::schema (
   $position   = 0,
   $files      = [],

--- a/templates/_security.erb
+++ b/templates/_security.erb
@@ -1,11 +1,10 @@
 ## Security requirements
 #
 
-password-hash <%= @password_hash %>
-<% if @password_salt_format -%>
-password-crypt-salt-format "<%= @password_salt_format %>"
+<% if @password_hash -%>password-hash <%= @password_hash %>
 <% end -%>
-
+<% if @password_salt_format -%>password-crypt-salt-format "<%= @password_salt_format %>"
+<% end -%>
 <% if @sec_require and ! @sec_require.empty? -%>
 <%- Array(@sec_require).each do |sec_require| -%>
 require <%= sec_require %>
@@ -22,8 +21,8 @@ allow <%= sec_allow %>
 localSSF <%= @local_ssf %>
 <% end -%>
 
-# minimum required SSF value (security strength factor)
-security <%= @security %>
+<% if @security -%>security <%= @security %>
+<% end -%>
 <% if @sec_disallow and ! @sec_disallow.empty? -%>
 <%- Array(@sec_disallow).each do |sec_disallow| -%>
 disallow <%= sec_disallow %>


### PR DESCRIPTION
- Removed default values for optional parameters / changed default values to match openldaps own default values. We should let the openldap handle the default values for optional params.
- Removed one un-used parameter "$schema_dir".

Puppet-lint founds:
- Added small header comment for all classes / defines.
- Double quotes -> single quotes.
- Removed trailing spaces.
